### PR TITLE
feat: Compute event status while addition

### DIFF
--- a/ctftime/event.go
+++ b/ctftime/event.go
@@ -2,33 +2,35 @@ package ctftime
 
 import (
 	"time"
+
+	"github.com/csivitu/bl0b/utils"
 )
 
 // Event defines a single event obtained from CTFtime
 type Event struct {
-	Organizers    []Organizer `json:"organizers"`
-	OnSite        bool        `json:"onsite" db:"OnSite"`
-	Finish        time.Time   `json:"finish" db:"Finish"`
-	Description   string      `json:"description" db:"Description"`
-	Weight        float64     `json:"weight" db:"Weight"`
-	Title         string      `json:"title" db:"Title"`
-	URL           string      `json:"url" db:"URL"`
-	IsVotableNow  bool        `json:"is_votable_now" db:"IsVotableNow"`
-	Restrictions  string      `json:"restrictions" db:"Restrictions"`
-	Format        string      `json:"format" db:"Format"`
-	Start         time.Time   `json:"start" db:"Start"`
-	Participants  int         `json:"participants" db:"Participants"`
-	CtftimeURL    string      `json:"ctftime_url" db:"CtftimeURL"`
-	Location      string      `json:"location" db:"Location"`
-	LiveFeed      string      `json:"live_feed" db:"LiveFeed" db:"LiveFeed"`
-	PublicVotable bool        `json:"public_votable" db:"PublicVotable"`
-	Duration      Duration    `json:"duration"`
-	Logo          string      `json:"logo" db:"Logo"`
-	FormatID      int         `json:"format_id" db:"FormatID"`
-	ID            int         `json:"id" db:"ID"`
-	CtfID         int         `json:"ctf_id" db:"CtfID"`
-	Status        Status      `db:"Status"`
-	Organizer     string      `db:"Organizer"`
+	Organizers    []Organizer  `json:"organizers"`
+	OnSite        bool         `json:"onsite" db:"OnSite"`
+	Finish        time.Time    `json:"finish" db:"Finish"`
+	Description   string       `json:"description" db:"Description"`
+	Weight        float64      `json:"weight" db:"Weight"`
+	Title         string       `json:"title" db:"Title"`
+	URL           string       `json:"url" db:"URL"`
+	IsVotableNow  bool         `json:"is_votable_now" db:"IsVotableNow"`
+	Restrictions  string       `json:"restrictions" db:"Restrictions"`
+	Format        string       `json:"format" db:"Format"`
+	Start         time.Time    `json:"start" db:"Start"`
+	Participants  int          `json:"participants" db:"Participants"`
+	CtftimeURL    string       `json:"ctftime_url" db:"CtftimeURL"`
+	Location      string       `json:"location" db:"Location"`
+	LiveFeed      string       `json:"live_feed" db:"LiveFeed" db:"LiveFeed"`
+	PublicVotable bool         `json:"public_votable" db:"PublicVotable"`
+	Duration      Duration     `json:"duration"`
+	Logo          string       `json:"logo" db:"Logo"`
+	FormatID      int          `json:"format_id" db:"FormatID"`
+	ID            int          `json:"id" db:"ID"`
+	CtfID         int          `json:"ctf_id" db:"CtfID"`
+	Status        utils.Status `db:"Status"`
+	Organizer     string       `db:"Organizer"`
 	// TODO: Later on replace Organizer with list of Organizers in new table
 }
 
@@ -48,15 +50,3 @@ type Duration struct {
 
 // Events is a slice of type Event
 type Events []Event
-
-// Status specifies the status of events in the database
-type Status string
-
-const (
-	// Upcoming status
-	Upcoming Status = "upcoming"
-	// Ongoing status
-	Ongoing Status = "ongoing"
-	// Over staatus
-	Over Status = "over"
-)

--- a/ctftime/events.go
+++ b/ctftime/events.go
@@ -10,8 +10,8 @@ import (
 // GetEvents returns events between startTime and endTime. The number
 // of events is defined by the value of limit.
 func (ctf *CTFtime) GetEvents(limit int, startTime time.Time, finishTime time.Time) (Events, error) {
-	start := startTime.Unix() * 1000
-	finish := finishTime.Unix() * 1000
+	start := startTime.Unix()
+	finish := finishTime.Unix()
 
 	endpoint := fmt.Sprintf(
 		"/events/?limit=%d&start=%d&finish=%d",

--- a/db/dbInit.go
+++ b/db/dbInit.go
@@ -97,7 +97,7 @@ func Init() error {
 			Description   VARCHAR(2000) NOT NULL,
 			Finish        DATETIME,
 			OnSite        BOOL,
-			Status        ENUM('ongoing', 'upcoming') DEFAULT 'upcoming',
+			Status        ENUM('ongoing', 'upcoming', 'over'),
 			Organizer     VARCHAR(100)
 		)
 	`)

--- a/db/eventsOps.go
+++ b/db/eventsOps.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/csivitu/bl0b/ctftime"
+	"github.com/csivitu/bl0b/utils"
 )
 
 // AddEvents adds a slice of Events in the database
@@ -17,7 +18,8 @@ func (DB *Database) AddEvents(events *ctftime.Events) error {
 		Format, Restrictions,
 		IsVotableNow, URL, Title,
 		Weight, Description,
-		Finish, OnSite, Organizer
+		Finish, OnSite, Organizer,
+		Status
 	`
 
 	params = strings.ReplaceAll(params, "\t", "")
@@ -39,7 +41,11 @@ func (DB *Database) AddEvents(events *ctftime.Events) error {
 
 	tx := DB.db.MustBegin()
 	for _, event := range *events {
-		tx.NamedExec(queryString, event)
+		event.Status = utils.ComputeStatus(event.Start, event.Finish)
+		_, err := tx.NamedExec(queryString, event)
+		if err != nil {
+			fmt.Println(err)
+		}
 	}
 
 	err := tx.Commit()
@@ -55,7 +61,7 @@ func (DB *Database) GetEvents() (ctftime.Events, error) {
 }
 
 // GetEventsByStatus returns events depending upon the Status attribute
-func (DB *Database) GetEventsByStatus(status ctftime.Status) (ctftime.Events, error) {
+func (DB *Database) GetEventsByStatus(status utils.Status) (ctftime.Events, error) {
 	var events ctftime.Events
 	err := DB.db.Select(&events, "SELECT * FROM events WHERE Status=? ORDER BY Start", status)
 
@@ -64,7 +70,7 @@ func (DB *Database) GetEventsByStatus(status ctftime.Status) (ctftime.Events, er
 
 // ModifyEventStatus modifies the status of the event
 // identified by the eventID
-func (DB *Database) ModifyEventStatus(eventID int, status ctftime.Status) error {
+func (DB *Database) ModifyEventStatus(eventID int, status utils.Status) error {
 	queryString := "UPDATE events SET Status=:status WHERE ID=:id"
 
 	_, err := DB.db.NamedExec(queryString,

--- a/db/eventsOps.go
+++ b/db/eventsOps.go
@@ -49,7 +49,7 @@ func (DB *Database) AddEvents(events *ctftime.Events) error {
 // GetEvents returns Events from the database
 func (DB *Database) GetEvents() (ctftime.Events, error) {
 	var events ctftime.Events
-	err := DB.db.Select(&events, "SELECT * FROM events")
+	err := DB.db.Select(&events, "SELECT * FROM events ORDER BY Start")
 
 	return events, err
 }
@@ -57,7 +57,7 @@ func (DB *Database) GetEvents() (ctftime.Events, error) {
 // GetEventsByStatus returns events depending upon the Status attribute
 func (DB *Database) GetEventsByStatus(status ctftime.Status) (ctftime.Events, error) {
 	var events ctftime.Events
-	err := DB.db.Select(&events, "SELECT * FROM events WHERE Status=?", status)
+	err := DB.db.Select(&events, "SELECT * FROM events WHERE Status=? ORDER BY Start", status)
 
 	return events, err
 }

--- a/mux/events.go
+++ b/mux/events.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/csivitu/bl0b/ctftime"
 	"github.com/csivitu/bl0b/db"
+	"github.com/csivitu/bl0b/utils"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -17,7 +18,7 @@ func (m *Mux) UpcomingEvents(ds *discordgo.Session, dm *discordgo.Message, ctx *
 	defer DB.Close()
 
 	numberOfEvents := 3
-	events, err := DB.GetEventsByStatus(ctftime.Upcoming)
+	events, err := DB.GetEventsByStatus(utils.Upcoming)
 
 	events = events[:numberOfEvents]
 	if err != nil {
@@ -35,7 +36,7 @@ func (m *Mux) OngoingEvents(ds *discordgo.Session, dm *discordgo.Message, ctx *C
 	DB := db.New()
 	defer DB.Close()
 
-	events, err := DB.GetEventsByStatus(ctftime.Ongoing)
+	events, err := DB.GetEventsByStatus(utils.Ongoing)
 	if err != nil {
 		log.Println(err)
 	}

--- a/routines/populate.go
+++ b/routines/populate.go
@@ -19,7 +19,7 @@ func populate(t time.Time) {
 	duration := time.Hour*24*7
 
 	// 7 days before and 7 days after
-	events, err := ctf.GetEvents(10, t.Add(-duration), t.Add(duration))
+	events, err := ctf.GetEvents(15, t.Add(-duration), t.Add(duration))
 
 	if err != nil {
 		log.Println(err)

--- a/routines/populate.go
+++ b/routines/populate.go
@@ -16,7 +16,10 @@ func populate(t time.Time) {
 
 	ctf := ctftime.New()
 
-	events, err := ctf.GetEvents(10, t, t.Add(time.Hour*24*7))
+	duration := time.Hour*24*7
+
+	// 7 days before and 7 days after
+	events, err := ctf.GetEvents(10, t.Add(-duration), t.Add(duration))
 
 	if err != nil {
 		log.Println(err)

--- a/routines/populate.go
+++ b/routines/populate.go
@@ -16,10 +16,8 @@ func populate(t time.Time) {
 
 	ctf := ctftime.New()
 
-	duration := time.Hour*24*7
-
-	// 7 days before and 7 days after
-	events, err := ctf.GetEvents(15, t.Add(-duration), t.Add(duration))
+	// 4 days before and 7 days after
+	events, err := ctf.GetEvents(30, t.Add(-time.Hour*24*4), t.Add(time.Hour*24*7))
 
 	if err != nil {
 		log.Println(err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,19 @@ import (
 	"time"
 )
 
+// Status specifies the status of events in the database
+type Status string
+
+const (
+	// Upcoming status
+	Upcoming Status = "upcoming"
+	// Ongoing status
+	Ongoing Status = "ongoing"
+	// Over staatus
+	Over Status = "over"
+)
+
+
 // HTTPResponseToStruct converts response from CTFtime into
 // to a struct specified by the param v
 func HTTPResponseToStruct(r *http.Response, v interface{}) error {
@@ -52,4 +65,19 @@ func SetInterval(f func(time.Time), t time.Duration) chan bool {
 		}
 	}()
 	return done
+}
+
+// ComputeStatus finds if a CTF is upcoming, ongoing or over
+func ComputeStatus(start time.Time, finish time.Time) Status {
+	t := time.Now()
+
+	if t.After(start) && t.Before(finish) {
+		return Ongoing
+	}
+
+	if t.Before(start) && t.Before(finish) {
+		return Upcoming
+	}
+
+	return Over
 }


### PR DESCRIPTION
# feat: Compute event status while addition

- Compute event status when adding to the DB
- Sort events, ordered by start time
- `ComputeStatus` is now a utility
- Bug: Do not notify when status is already over.
